### PR TITLE
Fix recipe to work with latest rattler-build release

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -20,7 +20,7 @@ build:
 requirements:
   host:
     - pip
-    - python ${{ python_min }}
+    - python ${{ python_min }}.*
     - flit-core >=3.8,<4
   run:
     - python >=${{ python_min }}
@@ -44,7 +44,7 @@ tests:
       - python -c "import flask_security"
     requirements:
       run:
-        - python ${{ python_min }}
+        - python ${{ python_min }}.*
         - setuptools  # passlib requires pkg_resources
 
 about:


### PR DESCRIPTION
Add explicit `.*` glob suffix to bare python version specifiers like `python ${{{{ python_min }}}}` to make them valid match specs.

This is a build-fix only — the existing package on conda-forge is unaffected, so no new build needs to be pushed. That's why the build number isn't bumped.